### PR TITLE
Added support of TLS 1.2 for both server and client

### DIFF
--- a/Invoke-SocksProxy.psm1
+++ b/Invoke-SocksProxy.psm1
@@ -296,13 +296,14 @@ function Invoke-ReverseSocksProxy{
                         $ret = getProxyConnection -remoteHost $remoteHost -remotePort $remotePort
                         $client = $ret[0]
                         $cliStream_clear = $ret[1]
-                }
+                }                
                 if($certFingerprint -eq ''){
                     $cliStream = New-Object System.Net.Security.SslStream($cliStream_clear,$false,({$true} -as[Net.Security.RemoteCertificateValidationCallback]));
                 }else{
                     $cliStream = New-Object System.Net.Security.SslStream($cliStream_clear,$false,({return $args[1].GetCertHashString() -eq $certFingerprint } -as[Net.Security.RemoteCertificateValidationCallback]));
                 }
-                $cliStream.AuthenticateAsClient($remoteHost)
+                $sslProtocols = [System.Security.Authentication.SslProtocols]::Tls12
+                $cliStream.AuthenticateAsClient($remoteHost, $null, $sslProtocols, $false)
                 Write-Host "Connected"
                 $currentTry = 0;
                 $buffer = New-Object System.Byte[] 32

--- a/ReverseSocksProxyHandler.py
+++ b/ReverseSocksProxyHandler.py
@@ -13,7 +13,7 @@ def main(handlerPort, proxyPort, certificate, privateKey):
 
 
 def handlerServer(q, handlerPort, certificate, privateKey):
-    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     context.load_cert_chain(certificate, privateKey)
     try:
         dock_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
This PR is to add support of TLS 1.2, since modern Python versions refuse to work with older TLS.